### PR TITLE
add Sepolia testnet, remove confusing NftMetadata in NearNftService

### DIFF
--- a/src/main/kotlin/id/walt/nftkit/Values.kt
+++ b/src/main/kotlin/id/walt/nftkit/Values.kt
@@ -6,6 +6,7 @@ object Values {
 
     const val ETHEREUM_MAINNET_CHAIN_ID: Long = 1
     const val ETHEREUM_TESTNET_GOERLI_CHAIN_ID: Long = 5
+    const val ETHEREUM_TESTNET_SEPOLIA_CHAIN_ID: Long = 11155111
     const val POLYGON_MAINNET_CHAIN_ID: Long = 137
     const val POLYGON_TESTNET_MUMBAI_CHAIN_ID: Long = 80001
     const val MOONBEAM_MAINNET_CHAIN_ID: Long = 1284
@@ -13,16 +14,19 @@ object Values {
 
     const val ETHEREUM_MAINNET_SCAN_API_URL= "api.etherscan.io"
     const val ETHEREUM_TESTNET_GOERLI_SCAN_API_URL = "api-goerli.etherscan.io"
+    const val ETHEREUM_TESTNET_SEPOLIA_SCAN_API_URL = "api-sepolia.etherscan.io"
     const val POLYGON_MAINNET_SCAN_API_URL = "api.polygonscan.com"
     const val POLYGON_TESTNET_MUMBAI_SCAN_API_URL = "api-testnet.polygonscan.com"
 
     const val ETHEREUM_MAINNET_BLOCK_EXPLORER_URL = "https://etherscan.io"
     const val ETHEREUM_TESTNET_GOERLI_BLOCK_EXPLORER_URL = "https://goerli.etherscan.io/"
+    const val ETHEREUM_TESTNET_SEPOLIA_BLOCK_EXPLORER_URL = "https://sepolia.etherscan.io/"
     const val POLYGON_MAINNET_BLOCK_EXPLORER_URL = "https://polygonscan.com"
     const val POLYGON_TESTNET_MUMBAI_BLOCK_EXPLORER_URL = "https://mumbai.polygonscan.com"
 
     const val ETHEREUM_MAINNET_ALCHEMY_URL = "https://eth-mainnet.alchemyapi.io/v2/"
     const val ETHEREUM_TESTNET_GOERLI_ALCHEMY_URL = "https://eth-goerli.g.alchemy.com/v2/"
+    const val ETHEREUM_TESTNET_SEPOLIA_ALCHEMY_URL = "https://eth-sepolia.g.alchemy.com/v2/"
     const val POLYGON_MAINNET_ALCHEMY_URL = "https://polygon-mainnet.g.alchemy.com/v2/"
     const val POLYGON_TESTNET_MUMBAI_ALCHEMY_URL = "https://polygon-mumbai.g.alchemy.com/v2/"
 

--- a/src/main/kotlin/id/walt/nftkit/chains/evm/erc721/Erc721TokenStandard.kt
+++ b/src/main/kotlin/id/walt/nftkit/chains/evm/erc721/Erc721TokenStandard.kt
@@ -288,6 +288,7 @@ object Erc721TokenStandard : IErc721TokenStandard {
         val chainId= when(chain){
             EVMChain.ETHEREUM -> Values.ETHEREUM_MAINNET_CHAIN_ID
             EVMChain.GOERLI -> Values.ETHEREUM_TESTNET_GOERLI_CHAIN_ID
+            EVMChain.SEPOLIA -> Values.ETHEREUM_TESTNET_SEPOLIA_CHAIN_ID
             EVMChain.POLYGON -> Values.POLYGON_MAINNET_CHAIN_ID
             EVMChain.MUMBAI -> Values.POLYGON_TESTNET_MUMBAI_CHAIN_ID
             EVMChain.ASTAR -> Values.ASTAR_MAINNET_CHAIN_ID

--- a/src/main/kotlin/id/walt/nftkit/services/NearNftService.kt
+++ b/src/main/kotlin/id/walt/nftkit/services/NearNftService.kt
@@ -86,17 +86,6 @@ data class OperationResult(
 data class nearOperationResult(
     val hash: String,
 )
-@Serializable
-data class NFTMetadata(
-    val spec: String,
-    val name: String,
-    val symbol: String,
-    val icon: String?= null,
-    val base_uri: String?= null,
-    val reference: String?= null,
-    val reference_hash: String?= null,
-
-)
 
 data class NearMintingParameter(
     val receiver_id: String,

--- a/src/main/kotlin/id/walt/nftkit/services/NftService.kt
+++ b/src/main/kotlin/id/walt/nftkit/services/NftService.kt
@@ -69,6 +69,7 @@ enum class Chain {
     ETHEREUM,
     POLYGON,
     GOERLI,
+    SEPOLIA,
     MUMBAI,
     TEZOS,
     GHOSTNET,
@@ -84,6 +85,7 @@ enum class EVMChain {
     ETHEREUM,
     POLYGON,
     GOERLI,
+    SEPOLIA,
     MUMBAI,
     ASTAR,
     MOONBEAM
@@ -429,6 +431,7 @@ object NftService {
             val url = when (chain) {
                 Chain.ETHEREUM -> Values.ETHEREUM_MAINNET_ALCHEMY_URL
                 Chain.GOERLI -> Values.ETHEREUM_TESTNET_GOERLI_ALCHEMY_URL
+                Chain.SEPOLIA -> Values.ETHEREUM_TESTNET_SEPOLIA_ALCHEMY_URL
                 Chain.POLYGON -> Values.POLYGON_MAINNET_ALCHEMY_URL
                 Chain.MUMBAI -> Values.POLYGON_TESTNET_MUMBAI_ALCHEMY_URL
                 Chain.TEZOS -> throw Exception("Tezos is not supported")

--- a/src/main/kotlin/id/walt/nftkit/services/WaltIdServices.kt
+++ b/src/main/kotlin/id/walt/nftkit/services/WaltIdServices.kt
@@ -8,7 +8,8 @@ import java.io.File
 import java.util.*
 
 
-data class Providers(val ethereum: String, val goerli: String, val polygon: String, val mumbai: String, val astar: String, val moonbeam: String, val opal: String, val unique: String)
+data class Providers(val ethereum: String, val goerli: String, val sepolia: String, val polygon: String, val mumbai: String, val astar: String, val moonbeam: String, val opal: String, val unique: String)
+
 data class ChainConfig(val providers: Providers, val privateKey: String)
 
 data class KeysConfig(val keys: Map<String, String>)
@@ -86,6 +87,7 @@ object WaltIdServices {
         return when (chain) {
             EVMChain.ETHEREUM -> Values.ETHEREUM_MAINNET_BLOCK_EXPLORER_URL
             EVMChain.GOERLI -> Values.ETHEREUM_TESTNET_GOERLI_BLOCK_EXPLORER_URL
+            EVMChain.SEPOLIA -> Values.ETHEREUM_TESTNET_SEPOLIA_BLOCK_EXPLORER_URL
             EVMChain.POLYGON -> Values.POLYGON_MAINNET_BLOCK_EXPLORER_URL
             EVMChain.MUMBAI -> Values.POLYGON_TESTNET_MUMBAI_BLOCK_EXPLORER_URL
             else -> {throw Exception("${chain.toString()} is not supported")}

--- a/src/main/kotlin/id/walt/nftkit/utilis/Common.kt
+++ b/src/main/kotlin/id/walt/nftkit/utilis/Common.kt
@@ -77,6 +77,7 @@ object Common {
         return when (chain) {
             EVMChain.ETHEREUM -> Values.ETHEREUM_MAINNET_SCAN_API_URL
             EVMChain.GOERLI -> Values.ETHEREUM_TESTNET_GOERLI_SCAN_API_URL
+            EVMChain.SEPOLIA -> Values.ETHEREUM_TESTNET_SEPOLIA_SCAN_API_URL
             EVMChain.POLYGON -> Values.POLYGON_MAINNET_SCAN_API_URL
             EVMChain.MUMBAI -> Values.POLYGON_TESTNET_MUMBAI_SCAN_API_URL
             else -> {throw Exception("${chain.toString()} is not supported")}
@@ -87,6 +88,7 @@ object Common {
         return when (chain) {
             EVMChain.ETHEREUM -> WaltIdServices.loadApiKeys().apiKeys.ethereumBlockExplorer
             EVMChain.GOERLI -> WaltIdServices.loadApiKeys().apiKeys.ethereumBlockExplorer
+            EVMChain.SEPOLIA -> WaltIdServices.loadApiKeys().apiKeys.ethereumBlockExplorer
             EVMChain.POLYGON -> WaltIdServices.loadApiKeys().apiKeys.polygonBlockExplorer
             EVMChain.MUMBAI -> WaltIdServices.loadApiKeys().apiKeys.polygonBlockExplorer
             else -> {throw Exception("${chain.toString()} is not supported")}
@@ -94,7 +96,7 @@ object Common {
     }
 
     fun isEVMChain(chain: Chain): Boolean{
-        val EVMChains= listOf(Chain.ETHEREUM, Chain.POLYGON, Chain.GOERLI, Chain.MUMBAI)
+        val EVMChains= listOf(Chain.ETHEREUM, Chain.POLYGON, Chain.GOERLI, Chain.SEPOLIA, Chain.MUMBAI)
         if(chain in EVMChains) return true
         return false
     }

--- a/src/main/kotlin/id/walt/nftkit/utilis/providers/ProviderFactory.kt
+++ b/src/main/kotlin/id/walt/nftkit/utilis/providers/ProviderFactory.kt
@@ -8,6 +8,7 @@ object ProviderFactory {
     fun getProvider(chain: EVMChain): Web3jInstance? = when (chain) {
         EVMChain.ETHEREUM -> EthereumWeb3()
         EVMChain.GOERLI -> GoerliWeb3()
+        EVMChain.SEPOLIA -> SepoliaWeb3()
         EVMChain.POLYGON -> PolygonWeb3()
         EVMChain.MUMBAI -> MumbaiWeb3()
         EVMChain.ASTAR -> AstarWeb3()

--- a/src/main/kotlin/id/walt/nftkit/utilis/providers/SepoliaWeb3.kt
+++ b/src/main/kotlin/id/walt/nftkit/utilis/providers/SepoliaWeb3.kt
@@ -1,0 +1,11 @@
+package id.walt.nftkit.utilis.providers
+
+import id.walt.nftkit.services.WaltIdServices
+import org.web3j.protocol.Web3j
+import org.web3j.protocol.http.HttpService
+
+class SepoliaWeb3 : Web3jInstance{
+    override fun getWeb3j(): Web3j {
+        return Web3j.build(HttpService(WaltIdServices.loadChainConfig().providers.sepolia))
+    }
+}

--- a/src/main/resources/walt-default.yaml
+++ b/src/main/resources/walt-default.yaml
@@ -14,6 +14,7 @@ azureKeyVaultConfig:
 providers:
     ethereum: "ethereum"
     goerli: "https://eth-goerli.g.alchemy.com/v2/5TYSteGJgJwJjaQTNN3j_4JtYcvdr3Uy"
+    sepolia: "https://eth-sepolia.g.alchemy.com/v2/MBOqmZ2X5rRqHqA4Mu_nB3cy9LqndpCX"
     polygon: "https://polygon-mainnet.g.alchemy.com/v2/5TYSteGJgJwJjaQTNN3j_4JtYcvdr3Uy"
     mumbai: "https://polygon-mumbai.g.alchemy.com/v2/5TYSteGJgJwJjaQTNN3j_4JtYcvdr3Uy"
     astar: "https://evm.astar.network"
@@ -52,8 +53,7 @@ apiKeys:
   ethereumBlockExplorer: "JGD5ZUUBHE8CUXPNKZASVQPHRGBMB7A5XV"
   polygonBlockExplorer: "DZ3PFVWGJE5B8DMDQPRZ5JFBR6U484B82G"
   alchemy: "yjbYhlaH3U_vfnTiRQ3miGQS0cKwQMkB"
-  nftstorage: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweDYwNDNEYThENjU2RTU3NTg2ZDk3MkM1ZDM5RUNENzI1NTNCM2Q1NjAiLCJpc3MiOiJuZnQtc3RvcmFnZSIsImlhdCI6MTY1NDYxNTQ2NjIwNCwibmFtZSI6Ik5GVCBLSVQifQ.PkMJpU3aJMQXqzq1nPnHJcWJR-32as3bQed3GBszMdg
-"
+  nftstorage: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweDYwNDNEYThENjU2RTU3NTg2ZDk3MkM1ZDM5RUNENzI1NTNCM2Q1NjAiLCJpc3MiOiJuZnQtc3RvcmFnZSIsImlhdCI6MTY1NDYxNTQ2NjIwNCwibmFtZSI6Ik5GVCBLSVQifQ.PkMJpU3aJMQXqzq1nPnHJcWJR-32as3bQed3GBszMdg"
   subscan: ""
 
  #for local dev use: tezosBackendServer: "http://localhost:3000"


### PR DESCRIPTION
Hello,

I have this PR with these changes below:
1. Add new testnet Sepolia, just because Goerli is really difficult for newbie to get faucet and it'll be shutdown at the end of this year
2. I see that data class NftMetadata in NearNftService cause projects using nftkit confused (currently there are 2 NftMetadata in services package, 1 in NearNftService and the other in NftService), even testing cannot be compiled. I think the one in NearNftService is not correct and not needed, please double check.