### PR TITLE
Repo relocated: https://github.com/walt-id/waltid-identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## 🚨 Repository Moved
+
+> [!IMPORTANT]
+> This repository is no longer maintained.
+> 
+> All walt.id development continues in the monorepo:
+> 
+### 👉 Code **https://github.com/walt-id/waltid-identity** & Docs **https://docs.walt.id**
+
 <div align="center">
  <h1>NFT Kit</h1>
  <span>by </span><a href="https://walt.id">walt.id</a>


### PR DESCRIPTION
Added a notice indicating the repository is no longer maintained and provided links to the new monorepo for continued development.